### PR TITLE
Fix the inclusion of the Mobicore new path

### DIFF
--- a/mobicore/daemon/Registry/Android.mk
+++ b/mobicore/daemon/Registry/Android.mk
@@ -8,4 +8,6 @@
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/Registry/Public
 
 # Add new source files here
-LOCAL_SRC_FILES += Registry/Registry.cpp
+LOCAL_SRC_FILES += \
+		Registry/PrivateRegistry.cpp \
+		Registry/Registry.cpp


### PR DESCRIPTION
The path was set from the old files,
so after this added, it can take it from here
